### PR TITLE
Peer discovery on IPv8

### DIFF
--- a/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
+++ b/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
@@ -62,6 +62,7 @@ import nl.tudelft.trustchain.common.bitcoin.WalletService
 import nl.tudelft.trustchain.common.eurotoken.GatewayStore
 import nl.tudelft.trustchain.common.eurotoken.TransactionRepository
 import nl.tudelft.trustchain.currencyii.CoinCommunity
+import nl.tudelft.trustchain.detoks.DeToksCommunity
 import nl.tudelft.trustchain.eurotoken.community.EuroTokenCommunity
 import nl.tudelft.trustchain.eurotoken.db.TrustStore
 import nl.tudelft.trustchain.gossipML.RecommenderCommunity
@@ -117,7 +118,8 @@ class TrustChainApplication : Application() {
                 createLiteratureCommunity(),
                 createRecommenderCommunity(),
                 createIdentityCommunity(),
-                createFOCCommunity()
+                createFOCCommunity(),
+                createDeToksCommunity()
             ),
             walkerInterval = 5.0
         )
@@ -443,6 +445,14 @@ class TrustChainApplication : Application() {
         val randomWalk = RandomWalk.Factory()
         return OverlayConfiguration(
             FOCCommunity.Factory(this),
+            listOf(randomWalk)
+        )
+    }
+
+    private fun createDeToksCommunity(): OverlayConfiguration<DeToksCommunity> {
+        val randomWalk = RandomWalk.Factory()
+        return OverlayConfiguration(
+            Overlay.Factory(DeToksCommunity::class.java),
             listOf(randomWalk)
         )
     }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
@@ -1,0 +1,39 @@
+package nl.tudelft.trustchain.detoks
+
+import android.util.Log
+import nl.tudelft.ipv8.Community
+import nl.tudelft.ipv8.IPv4Address
+import nl.tudelft.ipv8.messaging.Packet
+
+class DeToksCommunity() : Community() {
+
+    init {
+        messageHandlers[MESSAGE_TORRENT_ID] = ::onMessage
+    }
+
+    companion object {
+        const val MESSAGE_TORRENT_ID = 1
+    }
+
+    override val serviceId = "c86a7db45eb3563ae047639817baec4db2bc7c25"
+
+    override fun walkTo(address: IPv4Address) {
+        super.walkTo(address)
+
+        Log.d("DeToksCommunity", this.getPeers().toString())
+        broadcastTorrent() // FOR TESTING PURPOSES
+    }
+
+    fun broadcastTorrent() {
+        for (peer in getPeers()) {
+            Log.d("DeToksCommunity", "Sending torrent to $peer")
+            val packet = serializePacket(MESSAGE_TORRENT_ID, TorrentMessage("This is a torrent!"))
+            send(peer.address, packet)
+        }
+    }
+
+    private fun onMessage(packet: Packet) {
+        val (peer, payload) = packet.getAuthPayload(TorrentMessage.Deserializer)
+        Log.d("DeToksCommunity", peer.mid + ": " + payload.message)
+    }
+}

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksFragment.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksFragment.kt
@@ -45,7 +45,7 @@ class DeToksFragment : BaseFragment(R.layout.fragment_detoks) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        cacheDefaultTorrent()
+        cacheDefaultTorrent() //TODO: change to caching from peers
         torrentManager = TorrentManager(
             File("${requireActivity().cacheDir.absolutePath}/media"),
             File("${requireActivity().cacheDir.absolutePath}/torrent"),

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentMessage.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentMessage.kt
@@ -1,0 +1,19 @@
+package nl.tudelft.trustchain.detoks
+
+import nl.tudelft.ipv8.messaging.Deserializable
+import nl.tudelft.ipv8.messaging.Serializable
+
+class TorrentMessage(val message: String) : Serializable {
+
+    override fun serialize(): ByteArray {
+        return message.toByteArray()
+    }
+
+    companion object Deserializer : Deserializable<TorrentMessage> {
+        override fun deserialize(buffer: ByteArray, offset: Int): Pair<TorrentMessage, Int> {
+            return Pair(TorrentMessage(buffer.toString(Charsets.UTF_8)), buffer.size)
+        }
+    }
+
+
+}


### PR DESCRIPTION
Closes: #2 

From [this](https://github.com/Tribler/kotlin-ipv8/blob/master/doc/OverlayTutorial.md) tutorial:
"We can either define our own factory extending Overlay.Factory if we need to provide custom parameters to an overlay, or use the default implementation."
I used the default factory, since we do not (yet) need to add parameters to the overlay. It is good to keep in mind that there is options.

For now I also added the basic functionality of it sending peers messages in walkTo. In Logcat these messages are logged when sent and received. This can be removed later again, but it shows contact between peers is possible.