### PR TITLE
Clean code

### DIFF
--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
@@ -114,7 +114,8 @@ class DeToksCommunity(private val context: Context) : Community() {
 
         payload.data.forEach {
             torrentManager.profile.updateEntryWatchTime(
-                it.first, it.second,
+                it.first,
+                it.second,
                 false
             )
         }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
@@ -2,14 +2,13 @@ package nl.tudelft.trustchain.detoks
 
 import android.content.Context
 import android.util.Log
+import com.frostwire.jlibtorrent.Sha1Hash
 import nl.tudelft.ipv8.Community
 import nl.tudelft.ipv8.Overlay
 import nl.tudelft.ipv8.Peer
 import nl.tudelft.ipv8.messaging.Packet
 import nl.tudelft.ipv8.messaging.Serializable
-import nl.tudelft.trustchain.detoks.gossiper.BootGossiper
-import nl.tudelft.trustchain.detoks.gossiper.NetworkSizeGossiper
-import nl.tudelft.trustchain.detoks.gossiper.GossipMessage
+import nl.tudelft.trustchain.detoks.gossiper.*
 
 
 class DeToksCommunity(private val context: Context) : Community() {
@@ -101,36 +100,38 @@ class DeToksCommunity(private val context: Context) : Community() {
     }
 
     private fun onTorrentGossip(packet: Packet) {
-        val payload = packet.getPayload(GossipMessage.Deserializer)
+        val payload = packet.getPayload(TorrentMessage.Deserializer)
         val torrentManager = TorrentManager.getInstance(context)
-        payload.data.forEach { torrentManager.addTorrent(it as String) }
+        payload.data.forEach {
+            torrentManager.addTorrent(Sha1Hash(it.first), it.second)
+        }
     }
 
     private fun onWatchTimeGossip(packet: Packet) {
-        val (peer, payload) = packet.getAuthPayload(GossipMessage.Deserializer)
+        val (peer, payload) = packet.getAuthPayload(WatchTimeMessage.Deserializer)
         val torrentManager = TorrentManager.getInstance(context)
         Log.d(LOGGING_TAG, "Received watch time entry from ${peer.mid}, payload: ${payload.data}")
 
         payload.data.forEach {
             torrentManager.profile.updateEntryWatchTime(
-                (it as Pair<*, *>).first as String, it.second.toString().toLong(),
+                it.first, it.second,
                 false
             )
         }
     }
 
     private fun onNetworkSizeGossip(packet: Packet) {
-        val (peer, payload) = packet.getAuthPayload(GossipMessage.Deserializer)
+        val (peer, payload) = packet.getAuthPayload(NetworkSizeMessage.Deserializer)
         NetworkSizeGossiper.receivedResponse(payload, peer)
     }
 
     private fun onBootRequestGossip(packet: Packet) {
-        val (peer, _) = packet.getAuthPayload(GossipMessage.Deserializer)
+        val (peer, _) = packet.getAuthPayload(BootMessage.Deserializer)
         BootGossiper.receivedRequest(peer)
     }
 
     private fun onBootResponseGossip(packet: Packet) {
-        val (_, payload) = packet.getAuthPayload(GossipMessage.Deserializer)
+        val (_, payload) = packet.getAuthPayload(BootMessage.Deserializer)
         BootGossiper.receivedResponse(payload.data)
     }
 

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/Recommender.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/Recommender.kt
@@ -34,11 +34,11 @@ class Profile(
 }
 
 class Recommender {
-    private fun coinTossRecommender(magnets: HashMap<String, ProfileEntry>): Map<String, ProfileEntry> {
-        return magnets.map { it.key to it.value }.shuffled().toMap()
+    private fun coinTossRecommender(torrents: HashMap<String, ProfileEntry>): Map<String, ProfileEntry> {
+        return torrents.map { it.key to it.value }.shuffled().toMap()
     }
 
-    private fun watchTimeRecommender(magnets: HashMap<String, ProfileEntry>): Map<String, ProfileEntry> {
-        return magnets.toList().sortedBy { (_, entry) -> entry }.toMap()
+    private fun watchTimeRecommender(torrents: HashMap<String, ProfileEntry>): Map<String, ProfileEntry> {
+        return torrents.toList().sortedBy { (_, entry) -> entry }.toMap()
     }
 }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/Recommender.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/Recommender.kt
@@ -18,18 +18,18 @@ class ProfileEntry(
 }
 
 class Profile(
-    val magnets: HashMap<String, ProfileEntry> = HashMap()
+    val torrents: HashMap<String, ProfileEntry> = HashMap()
 ) {
     fun updateEntryWatchTime(key: String, time: Long, myUpdate: Boolean) {
-        if(!magnets.contains(key)) magnets[key] = ProfileEntry()
+        if(!torrents.contains(key)) torrents[key] = ProfileEntry()
 
         if (myUpdate) {
-            magnets[key]!!.watchTime += (time / NetworkSizeGossiper.networkSizeEstimate)
+            torrents[key]!!.watchTime += (time / NetworkSizeGossiper.networkSizeEstimate)
         } else {
-            magnets[key]!!.watchTime += time
-            magnets[key]!!.watchTime /= 2
+            torrents[key]!!.watchTime += time
+            torrents[key]!!.watchTime /= 2
         }
-        Log.i(DeToksCommunity.LOGGING_TAG, "Updated watchtime of $key to ${magnets[key]!!.watchTime}")
+        Log.i(DeToksCommunity.LOGGING_TAG, "Updated watchtime of $key to ${torrents[key]!!.watchTime}")
     }
 }
 

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
@@ -233,11 +233,11 @@ class TorrentManager private constructor (
         fileOrDirectory.delete()
     }
 
-    fun addTorrent(magnet: String) {
-        val torrentInfo = getInfoFromMagnet(magnet)?:return
-        val hash = torrentInfo.infoHash()
+    fun addTorrent(hash: Sha1Hash, magnet: String) {
+        if (sessionManager.find(hash) != null) return
 
-        if(sessionManager.find(hash) != null) return
+        val torrentInfo = getInfoFromMagnet(magnet)?:return
+
         Log.d(DeToksCommunity.LOGGING_TAG,"Adding new torrent: ${torrentInfo.name()}")
 
         sessionManager.download(torrentInfo, cacheDir)
@@ -354,3 +354,13 @@ class TorrentMediaInfo(
     val fileName: String,
     val fileURI: String,
 )
+
+class MagnetLink {
+    companion object {
+        fun hashFromMagnet(magnet: String) : String {
+            return magnet
+                .substringAfter("xt=urn:btih:")
+                .substringBefore("&")
+        }
+    }
+}

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
@@ -113,7 +113,7 @@ class TorrentManager private constructor (
             return
         }
         if (cachingAmount * 2 + 1 >= getNumberOfTorrents()) {
-            // FIXME: This could potentially lead to issues, since what happens if the user locks
+            // TODO: This could potentially lead to issues, since what happens if the user locks
             //        their screen or switches to another app for a while? Maybe this could be
             //        changed to a place in the video adapter as well, if we can detect maybe when
             //        a video is done playing and starts again, then update the duration if possible

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
@@ -119,7 +119,7 @@ class TorrentManager private constructor (
             //        a video is done playing and starts again, then update the duration if possible
             val uri = torrentFiles.gett(currentIndex).handle.makeMagnetUri()
             profile.updateEntryWatchTime(
-                uri,
+                MagnetLink.hashFromMagnet(uri),
                 updateTime(),
                 true)
             currentIndex = newIndex
@@ -136,7 +136,7 @@ class TorrentManager private constructor (
         }
         val uri = torrentFiles.gett(currentIndex).handle.makeMagnetUri()
         profile.updateEntryWatchTime(
-            uri,
+            MagnetLink.hashFromMagnet(uri),
             updateTime(),
         true)
         currentIndex = newIndex
@@ -184,7 +184,7 @@ class TorrentManager private constructor (
                                 it
                             )
                             torrentFiles.add(torrent)
-                            profile.magnets[torrent.handle.makeMagnetUri()] = ProfileEntry()
+                            profile.torrents[torrent.handle.makeMagnetUri()] = ProfileEntry()
                         }
                     }
                 }
@@ -272,11 +272,11 @@ class TorrentManager private constructor (
     }
 
     fun getWatchedTorrents(): List<String> {
-        return (profile.magnets.keys).toList()
+        return (profile.torrents.keys).toList()
     }
 
     fun getUnwatchedTorrents(): List<String> {
-        return (torrentFiles.map { it.handle.makeMagnetUri() } subtract profile.magnets.keys).toList()
+        return (torrentFiles.map { it.handle.makeMagnetUri() } subtract profile.torrents.keys).toList()
     }
 
     class TorrentHandler(

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/VideoAdapter.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/VideoAdapter.kt
@@ -62,7 +62,7 @@ class VideosAdapter(
                 mVideoView.setVideoPath(content.fileURI)
                 Log.i("DeToks", "Received content: ${content.fileURI}")
                 mVideoView.setOnPreparedListener { mp ->
-                    // NOTE: Log the duration here potentially
+                    // TODO: Log the duration here potentially
                     mProgressBar.visibility = View.GONE
                     mp.start()
                     if (videoScaling) {

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/BootGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/BootGossiper.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import nl.tudelft.ipv8.Peer
 import nl.tudelft.ipv8.android.IPv8Android
+import nl.tudelft.ipv8.messaging.Deserializable
 import nl.tudelft.trustchain.detoks.DeToksCommunity
 
 class BootGossiper(
@@ -35,7 +36,7 @@ class BootGossiper(
         randomPeers.forEach {
             deToksCommunity.gossipWith(
                 it,
-                GossipMessage(DeToksCommunity.MESSAGE_BOOT_REQUEST, listOf()),
+                BootMessage(listOf()),
                 DeToksCommunity.MESSAGE_BOOT_REQUEST
             )
         }
@@ -45,28 +46,39 @@ class BootGossiper(
         var running = true
 
         fun receivedRequest(peer: Peer) {
-            val data = listOf<Pair<String, Any>>(
-                Pair("NetworkSize", NetworkSizeGossiper.networkSizeEstimate)
+            val data = listOf(
+                Pair("NetworkSize", NetworkSizeGossiper.networkSizeEstimate.toString())
             )
             val deToksCommunity = IPv8Android.getInstance().getOverlay<DeToksCommunity>()!!
             deToksCommunity.gossipWith(
                 peer,
-                GossipMessage(DeToksCommunity.MESSAGE_BOOT_RESPONSE, data),
+                BootMessage(data),
                 DeToksCommunity.MESSAGE_BOOT_RESPONSE
             )
         }
 
-        fun receivedResponse(data: List<Any>) {
+        fun receivedResponse(data: List<Pair<String, String>>) {
             data.forEach {
-                when((it as Pair<*,*>).first as String) {
+                when(it.first) {
                     "NetworkSize" ->
-                        NetworkSizeGossiper.networkSizeEstimate = (it.second as String).toInt()
+                        NetworkSizeGossiper.networkSizeEstimate = it.second.toInt()
                     else ->
                         Log.d(DeToksCommunity.LOGGING_TAG, "Received data in boot message that wasn't recognized")
                 }
             }
             running = false
             Log.d(DeToksCommunity.LOGGING_TAG, "Received boot response, shutting down gossiper")
+        }
+    }
+}
+
+class BootMessage(data: List<Pair<String, String>>) : GossipMessage<String>(data) {
+    companion object Deserializer : Deserializable<BootMessage> {
+        override fun deserialize(buffer: ByteArray, offset: Int): Pair<BootMessage, Int> {
+            val msg = deserializeMessage(buffer, offset){
+                return@deserializeMessage Pair(it.getString(0), it.getString(1))
+            }
+            return Pair(BootMessage(msg.first), msg.second)
         }
     }
 }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/GossipMessage.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/GossipMessage.kt
@@ -1,41 +1,29 @@
 package nl.tudelft.trustchain.detoks.gossiper
 
-import nl.tudelft.ipv8.messaging.Deserializable
 import nl.tudelft.ipv8.messaging.Serializable
-import nl.tudelft.trustchain.detoks.DeToksCommunity
+import org.json.JSONArray
 
-class GossipMessage(
-    val id: Int,
-    val data: List<Any>
+abstract class GossipMessage<T>(
+    val data: List<Pair<String, T>>
     ) : Serializable {
 
 
     override fun serialize(): ByteArray {
-        var msg = data
-        if (id != DeToksCommunity.MESSAGE_TORRENT_ID) {
-            msg = msg.map { (it as Pair<*, *>).first.toString() + "~" + it.second.toString() }
-        }
-        return msg.joinToString("," ).toByteArray()
+        return JSONArray(data.map { JSONArray(arrayOf(it.first, it.second)) }.toTypedArray())
+            .toString().toByteArray()
     }
 
-    companion object Deserializer : Deserializable<GossipMessage> {
+    companion object Deserializer {
 
-        override fun deserialize(buffer: ByteArray, offset: Int): Pair<GossipMessage, Int> {
+        fun <T>deserializeMessage(buffer: ByteArray, offset: Int, func: (JSONArray) -> T): Pair<List<T>, Int> {
             val tempStr = String(buffer, offset,buffer.size - offset)
-            val tempList = tempStr.split(",")
+            val json = JSONArray(tempStr)
+            val entries = mutableListOf<T>()
 
-            if(tempList.size == 1 && tempList[0] == "")
-                return Pair(GossipMessage(0, listOf()), offset)
+            for (i in 0 until json.length())
+                entries.add(func(json.getJSONArray(i)))
 
-            if (!tempStr.contains("~"))
-                return Pair(GossipMessage(0, tempList), offset)
-
-            val entries: List<Pair<String, Any>> = tempList.map {
-                val strPair = it.split("~")
-                Pair(strPair[0], strPair[1])
-            }
-
-            return Pair(GossipMessage(0, entries), offset)
+            return Pair(entries, offset)
         }
     }
 }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/WatchTimeGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/WatchTimeGossiper.kt
@@ -1,7 +1,6 @@
 package nl.tudelft.trustchain.detoks.gossiper
 
 import android.content.Context
-import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -10,7 +9,6 @@ import nl.tudelft.ipv8.android.IPv8Android
 import nl.tudelft.ipv8.messaging.Deserializable
 import nl.tudelft.trustchain.detoks.DeToksCommunity
 import nl.tudelft.trustchain.detoks.TorrentManager
-import nl.tudelft.trustchain.detoks.gossiper.GossipMessage.Deserializer.deserializeMessage
 
 class WatchTimeGossiper(
     override val delay: Long,
@@ -34,7 +32,7 @@ class WatchTimeGossiper(
 
         val randomPeers = pickRandomN(deToksCommunity.getPeers(), peers)
         val randomProfileEntries = pickRandomN(
-            TorrentManager.getInstance(context).profile.magnets.entries.map { Pair(it.key, it.value.watchTime) },
+            TorrentManager.getInstance(context).profile.torrents.entries.map { Pair(it.key, it.value.watchTime) },
             blocks
         )
         if (randomPeers.isEmpty() || randomProfileEntries.isEmpty()) return

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/WatchTimeGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/WatchTimeGossiper.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import nl.tudelft.ipv8.android.IPv8Android
+import nl.tudelft.ipv8.messaging.Deserializable
 import nl.tudelft.trustchain.detoks.DeToksCommunity
 import nl.tudelft.trustchain.detoks.TorrentManager
+import nl.tudelft.trustchain.detoks.gossiper.GossipMessage.Deserializer.deserializeMessage
 
 class WatchTimeGossiper(
     override val delay: Long,
@@ -40,9 +42,20 @@ class WatchTimeGossiper(
         randomPeers.forEach {
             deToksCommunity.gossipWith(
                 it,
-                GossipMessage(DeToksCommunity.MESSAGE_WATCH_TIME_ID, randomProfileEntries),
+                WatchTimeMessage(randomProfileEntries),
                 DeToksCommunity.MESSAGE_WATCH_TIME_ID
             )
+        }
+    }
+}
+
+class WatchTimeMessage(data: List<Pair<String, Long>>) : GossipMessage<Long>(data) {
+    companion object Deserializer : Deserializable<WatchTimeMessage> {
+        override fun deserialize(buffer: ByteArray, offset: Int): Pair<WatchTimeMessage, Int> {
+            val msg = deserializeMessage(buffer, offset){
+                return@deserializeMessage Pair(it.getString(0), it.getLong(1))
+            }
+            return Pair(WatchTimeMessage(msg.first), msg.second)
         }
     }
 }


### PR DESCRIPTION
Closes: #27 

Made `GossipMessage` generic with JSON arrays. Each gossiper now has a message class defined in the same folder that says how to handle the types per message type. The torrent messages are now also pairs, with the key being the hash of a torrent and the value the magnet link. Removed all the casting.
The profiles identify videos by hashes.