### PR TITLE
35 optimization for seeding strategies

### DIFF
--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/Strategy.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/Strategy.kt
@@ -8,13 +8,14 @@ private val strategyComparators = mutableMapOf<Int, (Pair<TorrentHandler, Profil
 
     var isSeeding = false
 
-    var leachingStrategy = STRATEGY_RANDOM
+    var leechingStrategy = STRATEGY_RANDOM
     var seedingStrategy = STRATEGY_RANDOM
 
     var seedingBandwidthLimit = 0
     var storageLimit : Int = 0
 
     companion object {
+
         const val STRATEGY_RANDOM = 0
         const val STRATEGY_HIGHEST_WATCH_TIME = 1
         const val STRATEGY_LOWEST_WATCH_TIME = 2
@@ -63,4 +64,6 @@ private val strategyComparators = mutableMapOf<Int, (Pair<TorrentHandler, Profil
 
         return sortedHandlerProfile.map { it.first }.toMutableList()
     }
+
+
 }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/StrategyFragment.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/StrategyFragment.kt
@@ -12,6 +12,7 @@ import android.widget.*
 import androidx.appcompat.widget.SwitchCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.frostwire.jlibtorrent.TorrentHandle
 import kotlinx.android.synthetic.main.fragment_strategy.*
 import nl.tudelft.trustchain.common.ui.BaseFragment
 import nl.tudelft.trustchain.detoks.TorrentManager.TorrentHandler
@@ -165,19 +166,19 @@ class StrategyAdapter(private val strategyData: List<TorrentHandler>) : Recycler
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val handler = strategyData[position]
         val convBtoMB = 1000000
+        val status = handler.handle.status()
 
         holder.hashTextView.text = strategyData[position].handle.name()
 
-        holder.downloadTextView.text = (handler.handle.status().allTimeDownload()
+        holder.downloadTextView.text = (status.allTimeDownload()
             / convBtoMB).toString()
 
-        holder.uploadTextView.text = (strategyData[position].handle.status().allTimeUpload()
+        holder.uploadTextView.text = (status.allTimeUpload()
             / convBtoMB).toString()
 
         //TODO: replace by actual token balance
         holder.balanceTextView.text = (
-            (strategyData[position].handle.status().allTimeUpload()
-            - strategyData[position].handle.status().allTimeDownload())
+            (status.allTimeUpload() - status.allTimeDownload())
             / convBtoMB).toString()
     }
 

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/StrategyFragment.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/StrategyFragment.kt
@@ -52,16 +52,16 @@ class StrategyFragment :  BaseFragment(R.layout.fragment_strategy) {
         )
         arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
 
-        val leachingStrategySpinner = view.findViewById<Spinner>(R.id.leachingStrategy)
-        leachingStrategySpinner.adapter = arrayAdapter
-        leachingStrategySpinner.post {
-            leachingStrategySpinner.setSelection(torrentManager.strategies.leachingStrategy)
+        val leechingStrategySpinner = view.findViewById<Spinner>(R.id.leechingStrategy)
+        leechingStrategySpinner.adapter = arrayAdapter
+        leechingStrategySpinner.post {
+            leechingStrategySpinner.setSelection(torrentManager.strategies.leechingStrategy)
         }
-        setSpinnerActions(leachingStrategySpinner) {
-            if (it != torrentManager.strategies.leachingStrategy) {
+        setSpinnerActions(leechingStrategySpinner) {
+            if (it != torrentManager.strategies.leechingStrategy) {
                 return@setSpinnerActions
             }
-            torrentManager.updateLeachingStrategy(it)
+            torrentManager.updateLeechingStrategy(it)
         }
 
         val seedingSwitch = view.findViewById<SwitchCompat>(R.id.isSeeding)

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
@@ -299,7 +299,13 @@ class TorrentManager private constructor (
         seedingTorrents.clear()
 
         for (i in seedingTorrentsSorted.indices) {
-            val size = seedingTorrentsSorted[i].handle.status().total() / 1000000
+            seedingTorrentsSorted[i].handle.scrapeTracker()
+            val status = seedingTorrentsSorted[i].handle.status()
+            val seeders = status.numSeeds()
+            val leechers = status.numPeers() - seeders
+            if (leechers < seeders) continue
+
+            val size = status.total() / 1000000
 
             if (storage + size > strategies.storageLimit) continue
 

--- a/detoks/src/main/res/layout/fragment_strategy.xml
+++ b/detoks/src/main/res/layout/fragment_strategy.xml
@@ -24,11 +24,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@string/leaching_strategy"
+                android:text="@string/leeching_strategy"
                 android:textSize="16sp" />
 
             <Spinner
-                android:id="@+id/leachingStrategy"
+                android:id="@+id/leechingStrategy"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"

--- a/detoks/src/main/res/values/strings.xml
+++ b/detoks/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="title_activity_main_detoks">DeToks</string>
     <string name="seeding_strategy">Seeding Strategy</string>
-    <string name="leaching_strategy">Leaching Strategy</string>
+    <string name="leeching_strategy">Leeching Strategy</string>
     <string name="bandwidth_day_mb">Bandwidth per day (MB)</string>
     <string name="torrent_name">Torrent Name</string>
     <string name="download">Download</string>


### PR DESCRIPTION
Closes: #35 

1. If `leechers < seeders` the torrent is not seeded
2. Every `SEEDING_LOOP_TIME` the seeding strategy function is called again if seeding is active. This is a const in `TorrentManager`. This seemed like a better option then kicking seeds that aren't uploading for that time, since if it is still the best choice according to your strategy then you should not stop seeding it.
3. Changed 'leach' to 'leech' in the code (typo)
4. Set some timeouts to be longer (for downloading timeout and printing while downloading)
5. Called `status()` of `TorrentHandler` object less often for optimization
6. `storage += size` in the coroutine in `updateSeedingStrategy` doesn't work since it is asynch, now it is assumed downloading will always be successful