### PR TITLE
41 final additions for leeching and seeding

### DIFF
--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/StrategyFragment.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/StrategyFragment.kt
@@ -59,7 +59,7 @@ class StrategyFragment :  BaseFragment(R.layout.fragment_strategy) {
             leechingStrategySpinner.setSelection(torrentManager.strategies.leechingStrategy)
         }
         setSpinnerActions(leechingStrategySpinner) {
-            if (it != torrentManager.strategies.leechingStrategy) {
+            if (it == torrentManager.strategies.leechingStrategy) {
                 return@setSpinnerActions
             }
             torrentManager.updateLeechingStrategy(it)
@@ -75,7 +75,7 @@ class StrategyFragment :  BaseFragment(R.layout.fragment_strategy) {
             seedingStrategySpinner.setSelection(torrentManager.strategies.seedingStrategy)
         }
         setSpinnerActions(seedingStrategySpinner) {
-            if (it != torrentManager.strategies.seedingStrategy) {
+            if (it == torrentManager.strategies.seedingStrategy) {
                 return@setSpinnerActions
             }
             torrentManager.updateSeedingStrategy(strategyId = it)


### PR DESCRIPTION
Closes: #41 

Changes:
- Unwatched videos are now actually served to the user first. This is done by keeping track of the index where the unwatched videos start. If there are no more unwatched videos this index is the torrentFiles list size.
- New torrents are inserted into torrentFiles according to the leeching strategy using binary sort.
- If the leeching startegy is changed, it is applied to the unwatched videos, unless there are none, then it is just applied to the whole list. A torrent in the cache is preserved if it is again in the cache to not unnecessarily remove and download torrents again.
- Seed_mode was changed to share_mode, but remains very hard to test
- 