### PR TITLE
Change the watchtime gossiper to a more generic profile gossiper

### DIFF
--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
@@ -19,7 +19,7 @@ class DeToksCommunity(private val context: Context) : Community() {
     init {
         messageHandlers[MESSAGE_TORRENT_ID] = ::onTorrentGossip
         messageHandlers[MESSAGE_TRANSACTION_ID] = ::onTransactionMessage
-        messageHandlers[MESSAGE_WATCH_TIME_ID] = :: onWatchTimeGossip
+        messageHandlers[MESSAGE_PROFILE_ENTRY_ID] = :: onProfileEntryGossip
         messageHandlers[MESSAGE_NETWORK_SIZE_ID] = :: onNetworkSizeGossip
         messageHandlers[MESSAGE_BOOT_REQUEST] = :: onBootRequestGossip
         messageHandlers[MESSAGE_BOOT_RESPONSE] = :: onBootResponseGossip
@@ -29,7 +29,7 @@ class DeToksCommunity(private val context: Context) : Community() {
         const val LOGGING_TAG = "DeToksCommunity"
         const val MESSAGE_TORRENT_ID = 1
         const val MESSAGE_TRANSACTION_ID = 2
-        const val MESSAGE_WATCH_TIME_ID = 3
+        const val MESSAGE_PROFILE_ENTRY_ID = 3
         const val MESSAGE_NETWORK_SIZE_ID = 4
         const val MESSAGE_BOOT_REQUEST = 5
         const val MESSAGE_BOOT_RESPONSE = 6
@@ -108,16 +108,20 @@ class DeToksCommunity(private val context: Context) : Community() {
         }
     }
 
-    private fun onWatchTimeGossip(packet: Packet) {
-        val (_, payload) = packet.getAuthPayload(WatchTimeMessage.Deserializer)
+    private fun onProfileEntryGossip(packet: Packet) {
+        val (_, payload) = packet.getAuthPayload(ProfileEntryMessage.Deserializer)
         val torrentManager = TorrentManager.getInstance(context)
 
         payload.data.forEach {
-            torrentManager.profile.updateEntryWatchTime(
-                it.first,
-                it.second,
-                false
-            )
+            // TODO: Maybe make a merge(entry) function in the profile class
+            it.second.hopCount      // TODO: Ignore as its in torrent gossiper
+            it.second.duration      // TODO: Update the duration (if 0?)
+            it.second.uploadDate    // TODO: Update the upload date (if 0?)
+            it.second.timesSeen     // TODO: Set it to 0 if it does not exist
+            it.second.firstSeen     // TODO: Set it to 0 if it has not been seen
+            it.second.likes         // TODO: Take the highest value
+            it.second.watched       // TODO: Set it to false
+            torrentManager.profile.updateEntryWatchTime(it.first, it.second.watchTime, false)
         }
     }
 

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/DeToksCommunity.kt
@@ -111,18 +111,7 @@ class DeToksCommunity(private val context: Context) : Community() {
     private fun onProfileEntryGossip(packet: Packet) {
         val (_, payload) = packet.getAuthPayload(ProfileEntryMessage.Deserializer)
         val torrentManager = TorrentManager.getInstance(context)
-
-        payload.data.forEach {
-            // TODO: Maybe make a merge(entry) function in the profile class
-            it.second.hopCount      // TODO: Ignore as its in torrent gossiper
-            it.second.duration      // TODO: Update the duration (if 0?)
-            it.second.uploadDate    // TODO: Update the upload date (if 0?)
-            it.second.timesSeen     // TODO: Set it to 0 if it does not exist
-            it.second.firstSeen     // TODO: Set it to 0 if it has not been seen
-            it.second.likes         // TODO: Take the highest value
-            it.second.watched       // TODO: Set it to false
-            torrentManager.profile.updateEntryWatchTime(it.first, it.second.watchTime, false)
-        }
+        payload.data.forEach { torrentManager.profile.mergeWith(it.first, it.second) }
     }
 
     private fun onNetworkSizeGossip(packet: Packet) {

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/GossiperService.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/GossiperService.kt
@@ -5,8 +5,6 @@ import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
 import kotlinx.coroutines.*
-import nl.tudelft.ipv8.android.IPv8Android
-import nl.tudelft.trustchain.detoks.DeToksCommunity
 import kotlin.system.exitProcess
 
 class GossiperService : Service() {
@@ -20,7 +18,7 @@ class GossiperService : Service() {
         BootGossiper(1000L, 4),
         NetworkSizeGossiper(30000L, 4, 1),
         TorrentGossiper(4000L, 4, 4, this),
-        WatchTimeGossiper(4000L, 4, 4, this)
+        ProfileEntryGossiper(4000L, 4, 4, this)
     )
 
 


### PR DESCRIPTION
Closes #40 
```
on merging do the following

    var firstSeen:        0 if profile didnt exist as we havent received the torrent yet
    var watched:          nothing special
    var watchTime:        call the updatewatchtime function
    var duration:         this value is either 0 or the actual duration, pick the max
    var uploadDate:       this value is either 0 or the actual duration, pick the max
    var hopCount:         ignore it as we keep track of it with the torrent gossiper
    var timesSeen:        0 if profile didnt exist as we havent received the torrent yet
    var likes:            if we only know this values through gossiping just take the max, else take the most recent
```
changed the addprofile function to keep into account that firstseen and timesseen can be 0