### PR TITLE
Make the profile entries also use hash with video file index

### DIFF
--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/Profile.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/Profile.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.detoks
 
+import android.util.Log
 import com.frostwire.jlibtorrent.TorrentInfo
 import nl.tudelft.trustchain.detoks.gossiper.NetworkSizeGossiper
 import kotlin.math.min
@@ -22,6 +23,7 @@ class Profile(
     object ProfileConfig { const val MAX_DURATION_FACTOR  = 10 }
 
     fun addProfile(key: String): ProfileEntry {
+        Log.d(DeToksCommunity.LOGGING_TAG, "Added profile $key") // remove later
         if(!profiles.contains(key)) profiles[key] = ProfileEntry(timesSeen = 1)
         return profiles[key]!!
     }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/Profile.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/Profile.kt
@@ -23,7 +23,6 @@ class Profile(
     object ProfileConfig { const val MAX_DURATION_FACTOR  = 10 }
 
     fun addProfile(key: String): ProfileEntry {
-        Log.d(DeToksCommunity.LOGGING_TAG, "Added profile $key") // remove later
         if(!profiles.contains(key)) profiles[key] = ProfileEntry(timesSeen = 1)
         return profiles[key]!!
     }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
@@ -103,13 +103,9 @@ class TorrentManager private constructor(
         return torrentFiles.size
     }
 
-    fun createKey(hash: String, index: Int): String {
-        val torrent = torrentFiles.filter { hash == MagnetLink.hashFromMagnet(it.handle.makeMagnetUri()) }
-        return if(torrent.isEmpty()) "" else "$hash?index=$index"
-    }
-
     fun createKey(hash: Sha1Hash, index: Int): String {
-        return createKey(hash.toString(), index)
+        val torrent = torrentFiles.filter { hash == it.handle.infoHash() }
+        return if(torrent.isEmpty()) "" else "$hash?index=$index"
     }
 
     /**

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/TorrentManager.kt
@@ -89,7 +89,7 @@ class TorrentManager private constructor(
                     delay(100)
                 }
                 profile.updateEntryDuration(
-                    createKey(content.handle.makeMagnetUri(), content.fileIndex),
+                    createKey(MagnetLink.hashFromMagnet(content.handle.makeMagnetUri()), content.fileIndex),
                     content.getVideoDuration())
             }
             content.asMediaInfo()
@@ -103,8 +103,7 @@ class TorrentManager private constructor(
         return torrentFiles.size
     }
 
-    fun createKey(magnet: String, index: Int): String {
-        val hash = MagnetLink.hashFromMagnet(magnet)
+    fun createKey(hash: String, index: Int): String {
         val torrent = torrentFiles.filter { hash == MagnetLink.hashFromMagnet(it.handle.makeMagnetUri()) }
         return if(torrent.isEmpty()) "" else "$hash?index=$index"
     }
@@ -156,7 +155,7 @@ class TorrentManager private constructor(
     private fun notifyChangeUpdate() {
         val torrent = torrentFiles.gett(currentIndex) // TODO: make torrentFiles into unwatched videos
         val magnet = torrent.handle.makeMagnetUri()
-        val key = createKey(magnet, torrent.fileIndex)
+        val key = createKey(MagnetLink.hashFromMagnet(magnet), torrent.fileIndex)
         profile.updateEntryDuration(key, torrent.getVideoDuration())
         profile.updateEntryWatchTime(key, updateTime(), true)
     }
@@ -207,7 +206,7 @@ class TorrentManager private constructor(
                             val magnet = torrent.handle.makeMagnetUri()
                             getInfoFromMagnet(magnet)?.let { it2 ->
                                 profile.updateEntryUploadDate(
-                                    createKey(magnet, it),
+                                    createKey(MagnetLink.hashFromMagnet(magnet), it),
                                     it2
                                 )
                             }
@@ -289,7 +288,7 @@ class TorrentManager private constructor(
         if (sessionManager.find(hash) != null) {
             for (it in 0 until torrentInfo.numFiles()) {
                 if (!torrentInfo.files().fileName(it).endsWith(".mp4")) continue
-                profile.incrementTimesSeen(createKey(magnet, it))
+                profile.incrementTimesSeen(createKey(MagnetLink.hashFromMagnet(magnet), it))
             }
             return
         }
@@ -329,7 +328,7 @@ class TorrentManager private constructor(
                 torrentFiles.add(insertIndex, torrent)
                 getInfoFromMagnet(magnet)?.let { it2 ->
                     profile.updateEntryUploadDate(
-                        createKey(magnet, it),
+                        createKey(MagnetLink.hashFromMagnet(magnet), it),
                         it2
                     )
                 }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
@@ -48,7 +48,7 @@ class TorrentGossiper(
                 if (!fileName.endsWith(".mp4")) continue
 
                 // Create the unique video key and compose the profile contents into a list of data
-                val key = torrentManager.createKey(MagnetLink.hashFromMagnet(magnet), fileName)
+                val key = torrentManager.createKey(magnet, it)
                 val entry = torrentManager.profile.addProfile(key)
                 val data = listOf(
                     Pair("Key", key),

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
@@ -42,7 +42,7 @@ class TorrentGossiper(
         val randomMagnets = handlers.random(max).map { it.makeMagnetUri() }
 
         randomMagnets.forEach { it1 ->
-            val key = MagnetLink.hashFromMagnet(it1)
+            val key = torrentManager.createKey(MagnetLink.hashFromMagnet(it1), "?filename=FIXME")
             val entry = torrentManager.profile.addProfile(key)
             val data = listOf(
                 Pair("Key", key),
@@ -88,7 +88,6 @@ class TorrentGossiper(
                     "HopCount" -> profile.updateEntryHopCount(key, it.second.toInt())
                     else -> Log.d(DeToksCommunity.LOGGING_TAG, "Received data in torrent message that was not recognized")
                 }
-                // FIXME: Log.d(DeToksCommunity.LOGGING_TAG, "Updated ${it.first} using value ${it.second}") // remove later
             }
         }
     }

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
@@ -48,7 +48,7 @@ class TorrentGossiper(
                 if (!fileName.endsWith(".mp4")) continue
 
                 // Create the unique video key and compose the profile contents into a list of data
-                val key = torrentManager.createKey(MagnetLink.hashFromMagnet(magnet), it)
+                val key = torrentManager.createKey(torrentInfo.infoHash(), it)
                 val entry = torrentManager.profile.addProfile(key)
                 val data = listOf(
                     Pair("Key", key),

--- a/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
+++ b/detoks/src/main/java/nl/tudelft/trustchain/detoks/gossiper/TorrentGossiper.kt
@@ -48,7 +48,7 @@ class TorrentGossiper(
                 if (!fileName.endsWith(".mp4")) continue
 
                 // Create the unique video key and compose the profile contents into a list of data
-                val key = torrentManager.createKey(magnet, it)
+                val key = torrentManager.createKey(MagnetLink.hashFromMagnet(magnet), it)
                 val entry = torrentManager.profile.addProfile(key)
                 val data = listOf(
                     Pair("Key", key),


### PR DESCRIPTION
Added a `createKey(magnet: String, fileName: String)` function which should be used everywhere we try and access the profile, I had to add looping through the files in some places, ~~I think it all works but I am not sure if I missed some places (as I cannot find other peers on eduroam,~~ will test this tonight ~~) I could change using the magnet in this function to using the hash instead as well if we want to.~~ Using hash and file index now

Refactored some code to avoid duplicate code in `notifyChange()`

Removed some unused imports and made `getInfoFromMagnet(magnet: String)` public